### PR TITLE
Fix for Boost 1.59.0 compatibility.

### DIFF
--- a/test/airtsp/AirlineScheduleTestSuite.cpp
+++ b/test/airtsp/AirlineScheduleTestSuite.cpp
@@ -14,6 +14,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE InventoryTestSuite
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 // Boost Date-Time
 #include <boost/date_time/gregorian/gregorian.hpp>
 // StdAir
@@ -41,7 +42,11 @@ struct UnitTestConfig {
   /** Constructor. */
   UnitTestConfig() {
     boost_utf::unit_test_log.set_stream (utfReportStream);
+#if BOOST_VERSION >= 105900
+    boost_utf::unit_test_log.set_format (boost_utf::OF_XML);
+#else
     boost_utf::unit_test_log.set_format (boost_utf::XML);
+#endif
     boost_utf::unit_test_log.set_threshold_level (boost_utf::log_test_units);
     //boost_utf::unit_test_log.set_threshold_level (boost_utf::log_successful_tests);
   }


### PR DESCRIPTION
Boost.Test has major changes in 1.59.0 including renaming the
XML enumerator to OF_XML.
